### PR TITLE
Use proper classId for queue related operations

### DIFF
--- a/src/frames/queue/bind-ok.ts
+++ b/src/frames/queue/bind-ok.ts
@@ -3,7 +3,7 @@ import { Frame } from '../frame'
 
 class BindOk extends Frame {
   constructor(channelId: number) {
-    super(FrameType.Method, ClassId.Exchange, ExchangeMethodId.BindOk, channelId)
+    super(FrameType.Method, ClassId.Queue, ExchangeMethodId.BindOk, channelId)
   }
 
   protected getPayload(): Buffer {

--- a/src/frames/queue/declare-ok.ts
+++ b/src/frames/queue/declare-ok.ts
@@ -3,7 +3,7 @@ import { Frame } from '../frame'
 
 class DeclareOk extends Frame {
   constructor(channelId: number) {
-    super(FrameType.Method, ClassId.Exchange, QueueMethodId.DeclareOk, channelId)
+    super(FrameType.Method, ClassId.Queue, QueueMethodId.DeclareOk, channelId)
   }
 
   protected getPayload(): Buffer {

--- a/src/frames/queue/delete-ok.ts
+++ b/src/frames/queue/delete-ok.ts
@@ -3,7 +3,7 @@ import { Frame } from '../frame'
 
 class DeleteOk extends Frame {
   constructor(channelId: number) {
-    super(FrameType.Method, ClassId.Exchange, ExchangeMethodId.DeleteOk, channelId)
+    super(FrameType.Method, ClassId.Queue, ExchangeMethodId.DeleteOk, channelId)
   }
 
   protected getPayload(): Buffer {

--- a/src/frames/queue/purge-ok.ts
+++ b/src/frames/queue/purge-ok.ts
@@ -3,7 +3,7 @@ import { Frame } from '../frame'
 
 class PurgeOk extends Frame {
   constructor(channelId: number) {
-    super(FrameType.Method, ClassId.Exchange, QueueMethodId.PurgeOk, channelId)
+    super(FrameType.Method, ClassId.Queue, QueueMethodId.PurgeOk, channelId)
   }
 
   protected getPayload(): Buffer {

--- a/src/frames/queue/unbind-ok.ts
+++ b/src/frames/queue/unbind-ok.ts
@@ -3,7 +3,7 @@ import { Frame } from '../frame'
 
 class UnBindOk extends Frame {
   constructor(channelId: number) {
-    super(FrameType.Method, ClassId.Exchange, ExchangeMethodId.UnBindOk, channelId)
+    super(FrameType.Method, ClassId.Queue, ExchangeMethodId.UnBindOk, channelId)
   }
 
   protected getPayload(): Buffer {


### PR DESCRIPTION


Fix classId for operations that were designating `exchange` instead of `queue`