### PR TITLE
bug(typescript): Fix error when compiling without skipLibCheck

### DIFF
--- a/src/onPublish.d.ts
+++ b/src/onPublish.d.ts
@@ -1,3 +1,0 @@
-import { Message } from './message'
-
-type onPublishCallback = (message: Message) => void

--- a/src/onPublish.ts
+++ b/src/onPublish.ts
@@ -1,0 +1,3 @@
+import { Message } from './message'
+
+export type onPublishCallback = (message: Message) => void


### PR DESCRIPTION
An issue occured when the lib was imported in a project using
typescript, and the project itself did not use the typescript option skipLibCheck.

This commit fix this issue.